### PR TITLE
Fix build for Windows and Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ CMakeCache.txt
 # Build files
 Makefile
 *.so
+build/
 
 # Don't include any virtual envs
 venv/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,21 @@ set(CMAKE_BUILD_TYPE Debug)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+set(CMAKE_CXX_STANDARD 17)
+
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
+
 # Python version to build for
 # set(PYBIND11_PYTHON_VERSION "3.11")
 
 add_subdirectory(pybind11)
 add_subdirectory(J3DUltra)
 
-pybind11_add_module(J3DUltra src/main.cpp)
+pybind11_add_module(J3DUltraPy src/main.cpp)
 
-target_include_directories(J3DUltra PUBLIC J3DUltra/include J3DUltra/lib/bStream pybind11/pybind11)
+target_include_directories(J3DUltraPy PUBLIC J3DUltra/include J3DUltra/lib/bStream pybind11/pybind11)
 
-target_link_libraries(J3DUltra PUBLIC j3dultra pybind11::embed)
+target_link_libraries(J3DUltraPy PUBLIC j3dultra pybind11::embed)
+
+# Build as 'J3DUltraPy' but rename to 'J3DUltra' afterwards to avoid naming conflicts during the build.
+set_target_properties(J3DUltraPy PROPERTIES OUTPUT_NAME J3DUltra)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,8 @@
+{
+    "name" : "pyj3dultra",
+    "version-string" : "pyj3dultra-win",
+    "dependencies": [
+        "zlib",
+        "libpng"
+    ]
+}


### PR DESCRIPTION
Various minor fixes to get builds working on other platforms.

I found a slightly less hacky workaround for the naming conflict on windows I mentioned before.

Also added a copy of J3DUltra's vcpkg.json, as building from the PyJ3DUltra root directory doesn't seem to work if that file only exists in a subdirectory.